### PR TITLE
Don't ignore `download_limit`

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -64,7 +64,7 @@ impl UploadInitPost {
             content_hash: Vec::from_hex(&self.content_hash)?,
             access_password: Vec::from_hex(&self.access_password)?,
             deletion_password: deletion_password,
-            download_limit: self.download_limit.map(|n| n as i32).and(CONFIG.download_limit_default),
+            download_limit: self.download_limit.map(|n| n as i32).or(CONFIG.download_limit_default),
             expire_date: expire_date,
         })
     }

--- a/web/src/components/Upload.js
+++ b/web/src/components/Upload.js
@@ -106,11 +106,13 @@ class Upload extends Component {
         const contentHashHex = Buffer.from(contentHash).toString('Hex')
         console.log('content hash', contentHashHex)
         const params = {
+          nonce: nonceHex,
           file_name: file.name,
           content_hash: contentHashHex,
-          nonce: nonceHex,
           access_password: accessPassHex,
-          deletion_password: deletePassHex
+          deletion_password: deletePassHex,
+          download_limit: downloadLimit,
+          lifespan: lifespan,
         }
         const headers = {headers: {'content-type': 'application/json'}}
         encryptUploadData(data, params, headers)


### PR DESCRIPTION
issue #1
- `Option::and` always returns `None` in this case I meant `or`
- `download_limit` and `lifespan` weren't being sent by the web frontend